### PR TITLE
Fixed #5, added RSSI from SA868, fixed compiler warnings.

### DIFF
--- a/src/DRA818.cpp
+++ b/src/DRA818.cpp
@@ -73,6 +73,8 @@ void DRA818::set_log(Stream *log) {
 
 int DRA818::read_response() {
   char ack[3];
+  ack[0] = ack[1] = ack[2] = '\0';  // Just to quiet some warnings.
+
   LOG(print, F("<- "));
 
   ack[2]=0;
@@ -103,11 +105,11 @@ int DRA818::group(uint8_t bw, float freq_tx, float freq_rx, uint8_t ctcss_tx, ui
   CHECK(bw, <, DRA818_12K5);
   CHECK(bw, >, DRA818_25K);
 
-  CHECK(freq_rx, <, (this->type & DRA818_BAND_FLAG == DRA818_VHF ? DRA818_VHF_MIN : DRA818_UHF_MIN));
-  CHECK(freq_tx, <, (this->type & DRA818_BAND_FLAG == DRA818_VHF ? DRA818_VHF_MIN : DRA818_UHF_MIN));
+  CHECK(freq_rx, <, ((this->type & DRA818_BAND_FLAG) == DRA818_VHF ? DRA818_VHF_MIN : DRA818_UHF_MIN));
+  CHECK(freq_tx, <, ((this->type & DRA818_BAND_FLAG) == DRA818_VHF ? DRA818_VHF_MIN : DRA818_UHF_MIN));
 
-  CHECK(freq_rx, >, (this->type & DRA818_BAND_FLAG == DRA818_VHF ? DRA818_VHF_MAX : DRA818_UHF_MAX));
-  CHECK(freq_tx, >, (this->type & DRA818_BAND_FLAG == DRA818_VHF ? DRA818_VHF_MAX : DRA818_UHF_MAX));
+  CHECK(freq_rx, >, ((this->type & DRA818_BAND_FLAG) == DRA818_VHF ? DRA818_VHF_MAX : DRA818_UHF_MAX));
+  CHECK(freq_tx, >, ((this->type & DRA818_BAND_FLAG) == DRA818_VHF ? DRA818_VHF_MAX : DRA818_UHF_MAX));
 
   CHECK(ctcss_rx, >, CTCSS_MAX);
   CHECK(ctcss_tx, >, CTCSS_MAX);
@@ -159,7 +161,7 @@ int DRA818::scan(float freq) {
 }
 
 int DRA818::rssi() {
-  if (this->type & DRA868_FLAG == 0) {
+  if ((this->type & DRA868_FLAG) == 0) {
     LOG(println, F("WARNING: DRA818::rssi() only supported by DRA/SA868, not 818."));
     LOG(println, F("Construct your DRA818 object with `type = DRA868_[VU]HF` to enable rssi()."))
     return -1;
@@ -201,17 +203,17 @@ int DRA818::filters(bool pre, bool high, bool low) {
   return read_response(); // SCAN function return 0 if there is a signal, 1 otherwise
 }
 
-static DRA818* DRA818::configure(SoftwareSerial *stream, uint8_t type, float freq_rx, float freq_tx, uint8_t squelch, uint8_t volume, uint8_t ctcss_rx, uint8_t ctcss_tx, uint8_t bandwidth, bool pre, bool high, bool low, Stream *log = NULL) {
+DRA818* DRA818::configure(SoftwareSerial *stream, uint8_t type, float freq_rx, float freq_tx, uint8_t squelch, uint8_t volume, uint8_t ctcss_rx, uint8_t ctcss_tx, uint8_t bandwidth, bool pre, bool high, bool low, Stream *log) {
   DRA818 *dra = new DRA818(stream, type);
   return DRA818::configure(dra, freq_rx, freq_tx, squelch, volume, ctcss_rx, ctcss_tx, bandwidth, pre, high, low, log);
 }
 
-static DRA818* DRA818::configure(HardwareSerial *stream, uint8_t type, float freq_rx, float freq_tx, uint8_t squelch, uint8_t volume, uint8_t ctcss_rx, uint8_t ctcss_tx, uint8_t bandwidth, bool pre, bool high, bool low, Stream *log = NULL) {
+DRA818* DRA818::configure(HardwareSerial *stream, uint8_t type, float freq_rx, float freq_tx, uint8_t squelch, uint8_t volume, uint8_t ctcss_rx, uint8_t ctcss_tx, uint8_t bandwidth, bool pre, bool high, bool low, Stream *log) {
   DRA818 *dra = new DRA818(stream, type);
   return DRA818::configure(dra, freq_rx, freq_tx, squelch, volume, ctcss_rx, ctcss_tx, bandwidth, pre, high, low, log);
 }
 
-static DRA818* DRA818::configure(DRA818 *dra, float freq_rx, float freq_tx, uint8_t squelch, uint8_t volume, uint8_t ctcss_rx, uint8_t ctcss_tx, uint8_t bandwidth, bool pre, bool high, bool low, Stream *log = NULL) {
+DRA818* DRA818::configure(DRA818 *dra, float freq_rx, float freq_tx, uint8_t squelch, uint8_t volume, uint8_t ctcss_rx, uint8_t ctcss_tx, uint8_t bandwidth, bool pre, bool high, bool low, Stream *log) {
   int ret;
 #ifdef DRA818_DEBUG
   dra->set_log(log);

--- a/src/DRA818.cpp
+++ b/src/DRA818.cpp
@@ -103,11 +103,11 @@ int DRA818::group(uint8_t bw, float freq_tx, float freq_rx, uint8_t ctcss_tx, ui
   CHECK(bw, <, DRA818_12K5);
   CHECK(bw, >, DRA818_25K);
 
-  CHECK(freq_rx, <, (this->type == DRA818_VHF ? DRA818_VHF_MIN : DRA818_UHF_MIN));
-  CHECK(freq_tx, <, (this->type == DRA818_VHF ? DRA818_VHF_MIN : DRA818_UHF_MIN));
+  CHECK(freq_rx, <, (this->type & DRA818_BAND_FLAG == DRA818_VHF ? DRA818_VHF_MIN : DRA818_UHF_MIN));
+  CHECK(freq_tx, <, (this->type & DRA818_BAND_FLAG == DRA818_VHF ? DRA818_VHF_MIN : DRA818_UHF_MIN));
 
-  CHECK(freq_rx, >, (this->type == DRA818_VHF ? DRA818_VHF_MAX : DRA818_UHF_MAX));
-  CHECK(freq_tx, >, (this->type == DRA818_VHF ? DRA818_VHF_MAX : DRA818_UHF_MAX));
+  CHECK(freq_rx, >, (this->type & DRA818_BAND_FLAG == DRA818_VHF ? DRA818_VHF_MAX : DRA818_UHF_MAX));
+  CHECK(freq_tx, >, (this->type & DRA818_BAND_FLAG == DRA818_VHF ? DRA818_VHF_MAX : DRA818_UHF_MAX));
 
   CHECK(ctcss_rx, >, CTCSS_MAX);
   CHECK(ctcss_tx, >, CTCSS_MAX);
@@ -159,6 +159,11 @@ int DRA818::scan(float freq) {
 }
 
 int DRA818::rssi() {
+  if (this->type & DRA868_FLAG == 0) {
+    LOG(println, F("WARNING: DRA818::rssi() only supported by DRA/SA868, not 818."));
+    LOG(println, F("Construct your DRA818 object with `type = DRA868_[VU]HF` to enable rssi()."))
+    return -1;
+  }
   LOG(println, F("DRA818::rssi"));
   LOG(print, F("-> "));
 

--- a/src/DRA818.cpp
+++ b/src/DRA818.cpp
@@ -158,6 +158,15 @@ int DRA818::scan(float freq) {
   return read_response();
 }
 
+int DRA818::rssi() {
+  LOG(println, F("DRA818::rssi"));
+  LOG(print, F("-> "));
+
+  SEND("AT+RSSI?");
+
+  return read_response();
+}
+
 int DRA818::volume(uint8_t volume) {
   CHECK(volume, >, VOLUME_MAX);
   CHECK(volume, <, VOLUME_MIN);

--- a/src/DRA818.cpp
+++ b/src/DRA818.cpp
@@ -116,8 +116,8 @@ int DRA818::group(uint8_t bw, float freq_tx, float freq_rx, uint8_t ctcss_tx, ui
 
   CHECK(squelch, >, SQUELCH_MAX);
 
-  dtostrf(freq_tx, 8, 4, buf_rx);
-  dtostrf(freq_rx, 8, 4, buf_tx);
+  dtostrf(freq_tx, 8, 4, buf_tx);
+  dtostrf(freq_rx, 8, 4, buf_rx);
 
   sprintf(buffer, "AT+DMOSETGROUP=%01d,%s,%s,%04d,%c,%04d\r\n", bw, buf_tx, buf_rx, ctcss_tx, squelch + '0', ctcss_rx);
 

--- a/src/DRA818.h
+++ b/src/DRA818.h
@@ -25,8 +25,16 @@
 #include <HardwareSerial.h>
 #include <SoftwareSerial.h>
 
+// Which bit of `type` to look at to determine the band
+#define DRA818_BAND_FLAG  0x1
+// Which bit of `type` to look at to determin whether it's an 818 or an 868
+#define DRA868_FLAG       0x2
+
 #define DRA818_VHF        0x0
 #define DRA818_UHF        0x1
+#define DRA868_VHF        (DRA818_VHF & DRA868_FLAG)
+#define DRA868_UHF        (DRA818_UHF & DRA868_FLAG)
+
 #define DRA818_VHF_MIN    134.0
 #define DRA818_VHF_MAX    174.0
 #define DRA818_UHF_MIN    400.0

--- a/src/DRA818.h
+++ b/src/DRA818.h
@@ -48,6 +48,8 @@ class DRA818 {
         int scan(float freq);
         int volume(uint8_t volume);
         int filters(bool pre, bool high, bool low);
+        int rssi();
+
 
         // serial connection to DRA818
         Stream *serial;


### PR DESCRIPTION
1. Fixed https://github.com/fatpat/arduino-dra818/issues/5
2. Added support for RSSI API call (see datasheet on https://www.nicerf.com/products/detail/2w-embedded-walkie-talkie-module-sa868.html) and the #defines to differentiate between DRA818 and 868.
3. Cleaned up some compiler warnings.  (I think this may address https://github.com/fatpat/arduino-dra818/issues/3 too)