### PR TITLE
Fix missing semicolon

### DIFF
--- a/src/DRA818.cpp
+++ b/src/DRA818.cpp
@@ -163,7 +163,7 @@ int DRA818::scan(float freq) {
 int DRA818::rssi() {
   if ((this->type & DRA868_FLAG) == 0) {
     LOG(println, F("WARNING: DRA818::rssi() only supported by DRA/SA868, not 818."));
-    LOG(println, F("Construct your DRA818 object with `type = DRA868_[VU]HF` to enable rssi()."))
+    LOG(println, F("Construct your DRA818 object with `type = DRA868_[VU]HF` to enable rssi()."));
     return -1;
   }
   LOG(println, F("DRA818::rssi"));


### PR DESCRIPTION
When _DRA818_DEBUG_ is uncommented (https://github.com/fatpat/arduino-dra818/blob/master/src/DRA818.h#L44), the compilation is breaking due to the missing semicolon at the end of the line.