### PR TITLE
Added ESP32 support (no SofwtwareSerial available on ESP32)

### DIFF
--- a/src/DRA818.cpp
+++ b/src/DRA818.cpp
@@ -23,7 +23,9 @@
 #include <stdio.h>
 #include <Stream.h>
 #include <HardwareSerial.h>
+#if !defined (ESP32)
 #include <SoftwareSerial.h>
+#endif
 
 #define CTCSS_MAX           38
 #define SQUELCH_MAX         8
@@ -51,10 +53,13 @@ DRA818::DRA818(HardwareSerial *serial, uint8_t type) {
   serial->begin(SERIAL_SPEED, SERIAL_CONFIG);
   this->init((Stream *)serial, type);
 }
+
+#if !defined (ESP32)
 DRA818::DRA818(SoftwareSerial *serial, uint8_t type) {
   serial->begin(SERIAL_SPEED); // We can't configure bits/parity for SoftwareSerial, it's 8N1 as the DRA818
   this->init((Stream *)serial, type);
 }
+#endif
 
 void DRA818::init(Stream *serial, uint8_t type) {
   this->serial = serial;
@@ -203,10 +208,12 @@ int DRA818::filters(bool pre, bool high, bool low) {
   return read_response(); // SCAN function return 0 if there is a signal, 1 otherwise
 }
 
+#if !defined (ESP32)
 DRA818* DRA818::configure(SoftwareSerial *stream, uint8_t type, float freq_rx, float freq_tx, uint8_t squelch, uint8_t volume, uint8_t ctcss_rx, uint8_t ctcss_tx, uint8_t bandwidth, bool pre, bool high, bool low, Stream *log) {
   DRA818 *dra = new DRA818(stream, type);
   return DRA818::configure(dra, freq_rx, freq_tx, squelch, volume, ctcss_rx, ctcss_tx, bandwidth, pre, high, low, log);
 }
+#endif
 
 DRA818* DRA818::configure(HardwareSerial *stream, uint8_t type, float freq_rx, float freq_tx, uint8_t squelch, uint8_t volume, uint8_t ctcss_rx, uint8_t ctcss_tx, uint8_t bandwidth, bool pre, bool high, bool low, Stream *log) {
   DRA818 *dra = new DRA818(stream, type);

--- a/src/DRA818.cpp
+++ b/src/DRA818.cpp
@@ -113,8 +113,8 @@ int DRA818::group(uint8_t bw, float freq_tx, float freq_rx, uint8_t ctcss_tx, ui
   CHECK(freq_rx, <, ((this->type & DRA818_BAND_FLAG) == DRA818_VHF ? DRA818_VHF_MIN : DRA818_UHF_MIN));
   CHECK(freq_tx, <, ((this->type & DRA818_BAND_FLAG) == DRA818_VHF ? DRA818_VHF_MIN : DRA818_UHF_MIN));
 
-  CHECK(freq_rx, >, ((this->type & DRA818_BAND_FLAG) == DRA818_VHF ? DRA818_VHF_MAX : DRA818_UHF_MAX));
-  CHECK(freq_tx, >, ((this->type & DRA818_BAND_FLAG) == DRA818_VHF ? DRA818_VHF_MAX : DRA818_UHF_MAX));
+  CHECK(freq_rx, >, ((this->type & DRA818_BAND_FLAG) == DRA818_VHF ? DRA818_VHF_MAX : ((this->type & SA_MODEL_FLAG) == SA_MODEL_FLAG ? SA8X8_UHF_MAX : DRA818_UHF_MAX)));
+  CHECK(freq_tx, >, ((this->type & DRA818_BAND_FLAG) == DRA818_VHF ? DRA818_VHF_MAX : ((this->type & SA_MODEL_FLAG) == SA_MODEL_FLAG ? SA8X8_UHF_MAX : DRA818_UHF_MAX)));
 
   CHECK(ctcss_rx, >, CTCSS_MAX);
   CHECK(ctcss_tx, >, CTCSS_MAX);
@@ -166,15 +166,15 @@ int DRA818::scan(float freq) {
 }
 
 int DRA818::rssi() {
-  if ((this->type & DRA868_FLAG) == 0) {
-    LOG(println, F("WARNING: DRA818::rssi() only supported by DRA/SA868, not 818."));
-    LOG(println, F("Construct your DRA818 object with `type = DRA868_[VU]HF` to enable rssi()."));
+  if ((this->type & SA_MODEL_FLAG) == 0){
+    LOG(println, F("WARNING: DRA818::rssi() only supported by SA818/SA868, not by DRA818."));
+    LOG(println, F("Construct your DRA818 object with `type = SA[818]868_[VU]HF` to enable rssi()."));
     return -1;
   }
   LOG(println, F("DRA818::rssi"));
   LOG(print, F("-> "));
 
-  SEND("AT+RSSI?");
+  SEND("RSSI?");
 
   return read_response();
 }

--- a/src/DRA818.h
+++ b/src/DRA818.h
@@ -36,12 +36,12 @@
 
 #define DRA818_VHF        0x0
 #define DRA818_UHF        0x1
-#define DRA868_VHF        (DRA818_VHF & DRA868_FLAG)    // Not sure this model actually exist, leave it here for backward compatibility
-#define DRA868_UHF        (DRA818_UHF & DRA868_FLAG)    // Not sure this model actually exist, leave it here for backward compatibility
-#define SA818_VHF         (DRA818_VHF & SA_MODEL_FLAG)
-#define SA818_UHF         (DRA818_UHF & SA_MODEL_FLAG)
-#define SA868_VHF         (SA818_VHF & DRA868_FLAG)
-#define SA868_UHF         (SA818_UHF & DRA868_FLAG)
+#define DRA868_VHF        (DRA818_VHF | DRA868_FLAG)    // Not sure this model actually exist, leave it here for backward compatibility
+#define DRA868_UHF        (DRA818_UHF | DRA868_FLAG)    // Not sure this model actually exist, leave it here for backward compatibility
+#define SA818_VHF         (DRA818_VHF | SA_MODEL_FLAG)
+#define SA818_UHF         (DRA818_UHF | SA_MODEL_FLAG)
+#define SA868_VHF         (SA818_VHF | DRA868_FLAG)
+#define SA868_UHF         (SA818_UHF | DRA868_FLAG)
 
 #define DRA818_VHF_MIN    134.0
 #define DRA818_VHF_MAX    174.0

--- a/src/DRA818.h
+++ b/src/DRA818.h
@@ -23,7 +23,9 @@
 
 #include <Stream.h>
 #include <HardwareSerial.h>
+#if !defined (ESP32)
 #include <SoftwareSerial.h>
+#endif
 
 // Which bit of `type` to look at to determine the band
 #define DRA818_BAND_FLAG  0x1
@@ -47,7 +49,9 @@ class DRA818 {
     public:
         // Constructors
         DRA818(HardwareSerial *serial, uint8_t type);
+#if !defined (ESP32)
         DRA818(SoftwareSerial *serial, uint8_t type);
+#endif
         void init(Stream *serial, uint8_t type);
 
         // low level DRA818 function
@@ -69,7 +73,9 @@ class DRA818 {
 #endif
 
         // all-in-one configuration functions
+#if !defined (ESP32)
         static DRA818* configure(SoftwareSerial *stream, uint8_t type, float freq_rx, float freq_tx, uint8_t squelch, uint8_t volume, uint8_t ctcss_rx, uint8_t ctcss_tx, uint8_t bandwidth, bool pre, bool high, bool low, Stream *log = NULL);
+#endif
         static DRA818* configure(HardwareSerial *stream, uint8_t type, float freq_rx, float freq_tx, uint8_t squelch, uint8_t volume, uint8_t ctcss_rx, uint8_t ctcss_tx, uint8_t bandwidth, bool pre, bool high, bool low, Stream *log = NULL);
 
     private:

--- a/src/DRA818.h
+++ b/src/DRA818.h
@@ -31,16 +31,23 @@
 #define DRA818_BAND_FLAG  0x1
 // Which bit of `type` to look at to determin whether it's an 818 or an 868
 #define DRA868_FLAG       0x2
+// Which bit of `type` to look at to determin whether it's a DRA (Dorji) or an SA (NiceRF) model
+#define SA_MODEL_FLAG     0x4
 
 #define DRA818_VHF        0x0
 #define DRA818_UHF        0x1
-#define DRA868_VHF        (DRA818_VHF & DRA868_FLAG)
-#define DRA868_UHF        (DRA818_UHF & DRA868_FLAG)
+#define DRA868_VHF        (DRA818_VHF & DRA868_FLAG)    // Not sure this model actually exist, leave it here for backward compatibility
+#define DRA868_UHF        (DRA818_UHF & DRA868_FLAG)    // Not sure this model actually exist, leave it here for backward compatibility
+#define SA818_VHF         (DRA818_VHF & SA_MODEL_FLAG)
+#define SA818_UHF         (DRA818_UHF & SA_MODEL_FLAG)
+#define SA868_VHF         (SA818_VHF & DRA868_FLAG)
+#define SA868_UHF         (SA818_UHF & DRA868_FLAG)
 
 #define DRA818_VHF_MIN    134.0
 #define DRA818_VHF_MAX    174.0
 #define DRA818_UHF_MIN    400.0
 #define DRA818_UHF_MAX    470.0
+#define SA8X8_UHF_MAX     480.0
 #define DRA818_12K5       0x0
 #define DRA818_25K        0x1
 //#define DRA818_DEBUG


### PR DESCRIPTION
Salut Jérôme,

Petite PR si tu as 5 minutes pour permettre l'utilisation de ta lib avec un ESP32.
SoftwareSerial n'est pas dispo sur ESP32 car le HardwareSerial peut nativement être configuré sur n'importe quelle GPIO.
J'ai juste ajouté les directives de compilation pour désactiver SoftwareSerial sur les environnements ESP32.

A ta dispo si besoin,

Fred.